### PR TITLE
Вывод лога об отсутствии _secret_key в settings и env только при выключенном дебаге

### DIFF
--- a/celery_yandex_serverless/django.py
+++ b/celery_yandex_serverless/django.py
@@ -19,7 +19,7 @@ if _secret_key is None and not settings.DEBUG:
 def worker_view_factory(celery_app):
     @csrf_exempt
     def _worker_view(request, key: str):
-        if _secret_key is None and not settings.DEBUG:
+        if _secret_key is None:
             logging.error("Define CELERY_YANDEX_SERVERLESS_KEY settings with secret key for serverless worker")
             return JsonResponse({"status": "error", "message": "secret key is not set"}, status=500)
 

--- a/celery_yandex_serverless/django.py
+++ b/celery_yandex_serverless/django.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 
 _secret_key_slug = "CELERY_YANDEX_SERVERLESS_KEY"
 _secret_key = getattr(settings, _secret_key_slug, os.environ.get(_secret_key_slug))
-if _secret_key is None:
+if _secret_key is None and not settings.DEBUG:
     logger.error("Define CELERY_YANDEX_SERVERLESS_KEY settings with secret key for serverless worker")
 
 
 def worker_view_factory(celery_app):
     @csrf_exempt
     def _worker_view(request, key: str):
-        if _secret_key is None:
+        if _secret_key is None and not settings.DEBUG:
             logging.error("Define CELERY_YANDEX_SERVERLESS_KEY settings with secret key for serverless worker")
             return JsonResponse({"status": "error", "message": "secret key is not set"}, status=500)
 


### PR DESCRIPTION
Нужно же было отключить только первое предупреждение? Если нужно отключить логирование при дебаге в целом, то переделаю